### PR TITLE
Fix cooldown

### DIFF
--- a/src/Listeners/NotifyAdminOfError.php
+++ b/src/Listeners/NotifyAdminOfError.php
@@ -47,7 +47,7 @@ class NotifyAdminOfError
                     $existingError = json_decode(file_get_contents($errorFile), true);
                     $lastNotificationTime = $existingError['last_notified_at'] ?? null;
 
-                    if ($lastNotificationTime && now()->diffInMinutes($lastNotificationTime) < $cacheCooldown) {
+                    if ($lastNotificationTime && now()->diffInMinutes($lastNotificationTime, true) < $cacheCooldown) {
                         return;
                     }
                 }


### PR DESCRIPTION
Hello,

I noticed that the cooldown calc gives a negative result, so once an error is notified, it's never notified again until the json file is removed.

This solves that by using always an absolute time difference.