### PR TITLE
feat: add copy error button with multiple export formats

### DIFF
--- a/resources/views/details.blade.php
+++ b/resources/views/details.blade.php
@@ -63,6 +63,68 @@
             background-color: #43a047;
         }
 
+        .copy-dropdown {
+            position: fixed;
+            top: 20px;
+            right: 140px;
+            display: inline-block;
+        }
+
+        .copy-button {
+            background-color: #2196F3;
+            color: #ffffff;
+            border: none;
+            padding: 10px 15px;
+            font-size: 14px;
+            border-radius: 5px;
+            cursor: pointer;
+            box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+        }
+
+        .copy-button:hover {
+            background-color: #1976D2;
+        }
+
+        .dropdown-content {
+            display: none;
+            position: absolute;
+            background-color: #2e2e2e;
+            min-width: 200px;
+            box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.5);
+            border-radius: 5px;
+            z-index: 1;
+            margin-top: 5px;
+        }
+
+        .dropdown-content a {
+            color: #ffffff;
+            padding: 12px 16px;
+            text-decoration: none;
+            display: block;
+            border-radius: 5px;
+        }
+
+        .dropdown-content a:hover {
+            background-color: #3a3a3a;
+        }
+
+        .copy-dropdown.active .dropdown-content {
+            display: block;
+        }
+
+        .notification {
+            position: fixed;
+            top: 80px;
+            right: 20px;
+            background-color: #4caf50;
+            color: white;
+            padding: 15px 20px;
+            border-radius: 5px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            display: none;
+            z-index: 1000;
+        }
+
         .error-message {
             margin: 20px 0;
             padding: 15px;
@@ -140,13 +202,138 @@
         }
     </style>
     <script>
+        const errorData = @json($error);
+
+        // Toggle dropdown on click
+        window.addEventListener('DOMContentLoaded', function() {
+            const dropdown = document.querySelector('.copy-dropdown');
+            const button = dropdown.querySelector('.copy-button');
+
+            if (dropdown && button) {
+                button.addEventListener('click', function(e) {
+                    e.stopPropagation();
+                    dropdown.classList.toggle('active');
+                });
+
+                // Close dropdown when clicking outside
+                document.addEventListener('click', function(e) {
+                    if (!dropdown.contains(e.target)) {
+                        dropdown.classList.remove('active');
+                    }
+                });
+
+                // Close dropdown when clicking on a link
+                const links = dropdown.querySelectorAll('.dropdown-content a');
+                links.forEach(link => {
+                    link.addEventListener('click', function() {
+                        dropdown.classList.remove('active');
+                    });
+                });
+            }
+        });
+
+        function copyToClipboard(text) {
+            // Fallback pour les navigateurs sans clipboard API ou HTTP
+            const textArea = document.createElement('textarea');
+            textArea.value = text;
+            textArea.style.position = 'fixed';
+            textArea.style.left = '-999999px';
+            textArea.style.top = '-999999px';
+            document.body.appendChild(textArea);
+            textArea.focus();
+            textArea.select();
+
+            try {
+                document.execCommand('copy');
+                textArea.remove();
+                return true;
+            } catch (err) {
+                console.error('Failed to copy:', err);
+                textArea.remove();
+                return false;
+            }
+        }
+
         function shareUrl() {
             const url = window.location.href;
-            navigator.clipboard.writeText(url);
+            if (copyToClipboard(url)) {
+                showNotification('URL copied to clipboard!');
+            } else {
+                showNotification('Failed to copy URL');
+            }
+        }
+
+        function copyAsMarkdown() {
+            let markdown = '# Laravel Error Report\n\n';
+            markdown += '## Summary\n';
+            markdown += '**Error ID:** ' + errorData.id + '\n';
+            markdown += '**Message:** ' + errorData.message + '\n';
+            markdown += '**Environment:** ' + errorData.requestUri + '\n\n';
+
+            markdown += '## Context\n';
+            markdown += '- **File:** `' + errorData.file + '`\n';
+            markdown += '- **Line:** ' + errorData.line + '\n';
+            markdown += '- **URL:** ' + errorData.url + '\n';
+            markdown += '- **HTTP Method:** ' + errorData.method + '\n';
+            markdown += '- **Request Time:** ' + errorData.requestTime + '\n\n';
+
+            markdown += '## Request Details\n';
+            markdown += '- **IP Address:** ' + errorData.ip + '\n';
+            markdown += '- **User Agent:** ' + errorData.userAgent + '\n';
+            markdown += '- **Referrer:** ' + (errorData.referrer || 'Direct access') + '\n';
+            markdown += '- **Request URI:** ' + errorData.requestUri + '\n\n';
+
+            markdown += '## User Context\n';
+            if (errorData.authUser) {
+                markdown += '**Authenticated User:**\n';
+                markdown += '- ID: ' + errorData.authUser.id + '\n';
+                markdown += '- Name: ' + errorData.authUser.name + '\n';
+                markdown += '- Email: ' + errorData.authUser.email + '\n\n';
+            } else {
+                markdown += '**User:** Not authenticated (guest user)\n\n';
+            }
+
+            markdown += '## Stack Trace\n';
+            markdown += '```\n' + errorData.stackTrace + '\n```\n\n';
+            markdown += '---\n';
+            markdown += '*This error report contains all the context needed to debug and fix this issue.*\n';
+
+            if (copyToClipboard(markdown)) {
+                showNotification('Error copied as Markdown!');
+            } else {
+                showNotification('Failed to copy! Check console.');
+            }
+        }
+
+        function copyAsJSON() {
+            if (copyToClipboard(JSON.stringify(errorData, null, 2))) {
+                showNotification('Error copied as JSON!');
+            } else {
+                showNotification('Failed to copy! Check console.');
+            }
+        }
+
+        function showNotification(message) {
+            const notification = document.getElementById('notification');
+            notification.textContent = message;
+            notification.style.display = 'block';
+            setTimeout(() => {
+                notification.style.display = 'none';
+            }, 3000);
         }
     </script>
 </head>
 <body>
+<div id="notification" class="notification"></div>
+
+<div class="copy-dropdown">
+    <button class="copy-button">Copy Error</button>
+    <div class="dropdown-content">
+        <a href="#" onclick="event.preventDefault(); copyAsMarkdown();">Copy as Markdown</a>
+        <a href="#" onclick="event.preventDefault(); copyAsJSON();">Copy as JSON</a>
+    </div>
+</div>
+
 <button class="share-button" onclick="shareUrl()">Share URL</button>
 
 <div class="container">


### PR DESCRIPTION
Add a dropdown button to the error details page that allows copying error information in two formats:
- Copy as Markdown: Structured format perfect for documentation and issue tracking
- Copy as JSON: Raw data export for programmatic use

Features:
- Fixed position dropdown button next to Share URL button
- Visual notification toast confirming successful copy
- Fallback clipboard method for HTTP and older browsers compatibility
- Dropdown closes on outside click for better UX
- Enhanced Share URL button with notification feedback