### PR TITLE
feat(webhooks): add generic webhook endpoints support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A powerful Filament plugin that provides instant error notifications via email a
 
 - 📧 **Instant Email Notifications** - Get notified immediately when errors occur
 - 💬 **Discord Webhook Integration** - Send alerts to your Discord channels
+- 🔗 **Custom Webhook Endpoints** - POST raw error JSON to any number of URLs (n8n, Zapier, Slack apps, custom APIs)
 - 🎯 **Smart Application File Detection** - Automatically identifies errors in your code (excluding vendor files)
 - 🌓 **Beautiful Error Details Page** - Dark/Light mode with copy & share functionality
 - ⏱️ **Cooldown System** - Prevents notification spam for duplicate errors
@@ -22,6 +23,7 @@ A powerful Filament plugin that provides instant error notifications via email a
 - [Configuration](#configuration)
   - [Email Configuration](#email-configuration)
   - [Discord Webhook](#discord-webhook)
+  - [Custom Webhook Endpoints](#custom-webhook-endpoints)
   - [Error Filtering](#error-filtering)
   - [Cooldown Period](#cooldown-period)
   - [Storage Path](#storage-path)
@@ -71,6 +73,10 @@ return [
 
     'webhooks' => [
         'discord' => env('ERROR_MAILER_DISCORD_WEBHOOK'),
+
+        // Additional generic webhook URLs the plugin will POST the raw
+        // error details JSON to. Can also be set via env (CSV).
+        'endpoints' => array_values(array_filter(array_map('trim', explode(',', (string) env('ERROR_MAILER_WEBHOOK_URLS', ''))))),
 
         'message' => [
             'title' => 'Error Alert - ' . config('app.name'),
@@ -191,6 +197,60 @@ ERROR_MAILER_DISCORD_WEBHOOK="https://discord.com/api/webhooks/your-webhook-id/y
     ],
 ],
 ```
+
+### Custom Webhook Endpoints
+
+In addition to the Discord webhook, the plugin can POST the raw error details (as JSON) to any number of custom URLs. This is useful for forwarding errors to **n8n**, **Zapier**, **Slack apps**, a monitoring service, or your own internal API.
+
+**1. Via `.env` (comma-separated list):**
+
+```env
+ERROR_MAILER_WEBHOOK_URLS="https://hooks.example.com/error,https://n8n.example.com/webhook/abc123"
+```
+
+**2. Or directly in `config/error-mailer.php`:**
+
+```php
+'webhooks' => [
+    'discord' => env('ERROR_MAILER_DISCORD_WEBHOOK'),
+
+    'endpoints' => [
+        'https://hooks.example.com/error',
+        'https://n8n.example.com/webhook/abc123',
+        env('CUSTOM_MONITORING_WEBHOOK'),
+    ],
+
+    // ...
+],
+```
+
+Each URL receives a `POST` request with a JSON body containing the full error details:
+
+```json
+{
+    "id": "a1b2c3d4e5f6...",
+    "message": "Undefined variable $foo",
+    "file": "/app/Http/Controllers/UserController.php",
+    "line": 42,
+    "appFile": "/app/Http/Controllers/UserController.php",
+    "appLine": 42,
+    "url": "https://yourapp.com/users",
+    "method": "GET",
+    "ip": "1.2.3.4",
+    "userAgent": "Mozilla/5.0 ...",
+    "referrer": "https://yourapp.com/",
+    "requestTime": "2026-06-08 14:23:55",
+    "requestUri": "/users",
+    "authUser": { "id": 1, "name": "Jane", "email": "jane@example.com" },
+    "stackTrace": "...",
+    "last_notified_at": "2026-06-08 14:23:55",
+    "details_url": "https://yourapp.com/admin/error/a1b2c3d4...",
+    "app_name": "MyApp",
+    "app_url": "https://yourapp.com"
+}
+```
+
+Endpoints share the same cooldown as the email/Discord notifications — duplicate errors within `cacheCooldown` minutes are not re-sent.
 
 ### Error Filtering
 
@@ -392,6 +452,9 @@ return [
     // Webhook configuration
     'webhooks' => [
         'discord' => env('ERROR_MAILER_DISCORD_WEBHOOK'),
+
+        // Additional URLs to POST the raw error JSON to.
+        'endpoints' => array_values(array_filter(array_map('trim', explode(',', (string) env('ERROR_MAILER_WEBHOOK_URLS', ''))))),
 
         'message' => [
             'title' => 'Error Alert - ' . config('app.name'),

--- a/config/error-mailer.php
+++ b/config/error-mailer.php
@@ -17,6 +17,20 @@ return [
     'webhooks' => [
         'discord' => env('ERROR_MAILER_DISCORD_WEBHOOK'),
 
+        /*
+        |----------------------------------------------------------------------
+        | Generic Webhook Endpoints
+        |----------------------------------------------------------------------
+        |
+        | Additional webhook URLs the plugin will POST the raw error details
+        | JSON to. Useful for forwarding errors to Slack-via-app, n8n, Zapier,
+        | a custom API, etc. You may either list URLs directly or define them
+        | via the ERROR_MAILER_WEBHOOK_URLS env variable as a comma-separated
+        | list (e.g. https://a.example.com/hook,https://b.example.com/hook).
+        |
+        */
+        'endpoints' => array_values(array_filter(array_map('trim', explode(',', (string) env('ERROR_MAILER_WEBHOOK_URLS', ''))))),
+
         'message' => [
             'title' => 'Error Alert - ' . config('app.name'),
             'description' => 'An error has occurred in the application.',

--- a/src/Listeners/NotifyAdminOfError.php
+++ b/src/Listeners/NotifyAdminOfError.php
@@ -52,8 +52,11 @@ class NotifyAdminOfError
         // Send email notification
         $this->sendEmailNotification($exception, $errorHash);
 
-        // Send webhook notification
+        // Send Discord webhook notification
         $this->sendWebhookNotification($exception, $errorHash);
+
+        // POST raw error details to additional configured endpoints
+        $this->sendEndpointsNotification($errorDetails, $errorHash);
     }
 
     /**
@@ -100,5 +103,31 @@ class NotifyAdminOfError
 
         $payload = $this->discordWebhookBuilder->build($exception, $errorHash);
         WebhookNotifier::send($webhookUrl, $payload);
+    }
+
+    /**
+     * POST the raw error details JSON to every configured generic endpoint.
+     */
+    private function sendEndpointsNotification(array $errorDetails, string $errorHash): void
+    {
+        $endpoints = (array) config('error-mailer.webhooks.endpoints', []);
+
+        if (empty($endpoints)) {
+            return;
+        }
+
+        $payload = $errorDetails + [
+            'details_url' => route('error.details', ['errorId' => $errorHash]),
+            'app_name' => config('app.name'),
+            'app_url' => config('app.url'),
+        ];
+
+        foreach ($endpoints as $url) {
+            if (!is_string($url) || $url === '') {
+                continue;
+            }
+
+            WebhookNotifier::send($url, $payload);
+        }
     }
 }


### PR DESCRIPTION
- Add `webhooks.endpoints` config option to POST raw error JSON to arbitrary URLs (n8n, Zapier, Slack apps, custom APIs)
- Support `ERROR_MAILER_WEBHOOK_URLS` env variable as comma-separated list for easy configuration without code changes
- Call `sendEndpointsNotification()` after Discord webhook in listener
- Update README to document new webhook endpoints feature and add it to the feature list